### PR TITLE
Use github remote as PullReview::REPO

### DIFF
--- a/lib/pull_review.rb
+++ b/lib/pull_review.rb
@@ -8,7 +8,7 @@ module PullReview
   module Request; end
 
   TOKEN = File.readlines("#{ ENV['HOME'] }/.pullreview").first.chomp
-  REPO = `git remote -v | head -n 1 | cut -d':' -f2 | cut -d'.' -f1 | cut -d' ' -f1`.chomp
+  REPO = `git remote -v | grep github | head -n 1 | cut -d':' -f2 | cut -d'.' -f1 | cut -d' ' -f1`.chomp
 end
 
 require 'pull_review/bufferable'


### PR DESCRIPTION
Fix an issue with non-github git remotes which caused wrong github api
urls.